### PR TITLE
Support Laravel 12 and update php versions to PHP 8.3 and 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2",
+        "php": "^8.1|^8.2|^8.3|^8.4",
         "guzzlehttp/guzzle": "^7.9",
-        "illuminate/contracts": "^10.0 || ^11.0",
+        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^7.10 || ^8.1",
         "larastan/larastan": "^2.9 || v3.0.2",
-        "orchestra/testbench": "^8.22 || ^9.0",
+        "orchestra/testbench": "^8.22 || ^9.0 || ^10.0",
         "pestphp/pest": "^2.34 || ^3.5",
         "pestphp/pest-plugin-arch": "^2.7 || ^3.0",
         "pestphp/pest-plugin-laravel": "^2.3 || ^3.0",


### PR DESCRIPTION
I encountered a dependency conflict when attempting to install this package in a `Laravel 12` environment. The required packages were clashing with the currently available dependencies in the `Laravel 12` ecosystem.
To resolve this issue, I've modified the `composer.json` file to update the conflicting package constraints.

Additionally, since the codebase and all dependencies fully support up to PHP `8.3` and `8.4`, I have updated the upper PHP version constraint to ensure broader compatibility with the latest environments. 
This helps future-proof the package.